### PR TITLE
fix: Use a custom normalize_path to resolve duplicate symbol problem

### DIFF
--- a/parser/src/include_logic.rs
+++ b/parser/src/include_logic.rs
@@ -1,6 +1,36 @@
 use program_structure::error_definition::Report;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
+
+// Replacement for std::fs::canonicalize that doesn't verify the path exists
+// Plucked from https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
+// Advice from https://www.reddit.com/r/rust/comments/hkkquy/comment/fwtw53s/?utm_source=share&utm_medium=web2x&context=3
+fn normalize_path(path: &PathBuf) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}
 
 pub struct FileStack {
     current_location: PathBuf,
@@ -18,7 +48,9 @@ impl FileStack {
     pub fn add_include(f_stack: &mut FileStack, path: String) -> Result<(), Report> {
         let mut crr = f_stack.current_location.clone();
         crr.push(path.clone());
-        let path = crr;
+        // Replaced `std::fs::canonicalize` with a custom `normalize_path` function.
+        // No existence testing in wasm
+        let path = normalize_path(&crr);
         if !f_stack.black_paths.contains(&path) {
             f_stack.stack.push(path);
         }


### PR DESCRIPTION
I was thinking about upstreaming this, but I think they want the file existence check. @antimatter15 what do you think?