### PR TITLE
Fix circom forcibly exiting

### DIFF
--- a/npm/cli.js
+++ b/npm/cli.js
@@ -15,6 +15,12 @@ async function main() {
         preopens: preopensFull(),
         bindings: {
             ...bindings,
+            exit(code) {
+                process.exit(code)
+            },
+            kill(signal) {
+                process.kill(process.pid, signal)
+            },
             fs,
         },
     })


### PR DESCRIPTION
While investigating https://github.com/projectsophon/hardhat-circom/issues/72, I found that circom decided to forcibly exit the process in https://github.com/iden3/circom/commit/b953bf92df54004373a4049e29f0e160a5a57486. Of course this is a terrible decision but they are doing something really weird that causes circom to hit an `unreachable` if we remove the exit completely.

Anyway, this was killing hardhat-circom before it could finish doing the work it does. I could swap out the bindings but it feels better to smooth it over inside of this wrapper to actually make it return/exit gracefully.

I moved the process.exit call to the CLI exclusively because otherwise I'd still need to override the functions in hardhat-circom.